### PR TITLE
Fail early when NT functions can't be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Damit lassen sich NT-Funktionen bequem wie normale Windows-APIs nutzen, ohne jed
 
 1. **`ntinclude.h` und `ntinclude.c`** in der `main.c` einbinden:  
 
-2. Beim Start **Resolver aufrufen**:  
+2. Beim Start **Resolver aufrufen**:
 
    ```c
    if (!ResolveNtFunctions()) {
@@ -22,15 +22,19 @@ Damit lassen sich NT-Funktionen bequem wie normale Windows-APIs nutzen, ohne jed
 SIZE_T size = 0x1000;
 PVOID addr = NULL;
 
-if (NtAllocateVirtualMemory(
+NTSTATUS status = NtAllocateVirtualMemory(
     GetCurrentProcess(),
     &addr,
     0,
     &size,
     MEM_COMMIT | MEM_RESERVE,
     PAGE_READWRITE
-)) {
+);
+
+if (NT_SUCCESS(status)) {
     printf("Speicher allokiert bei %p\n", addr);
+} else {
+    printf("NtAllocateVirtualMemory fehlgeschlagen: 0x%lx\n", status);
 }
 ```
 

--- a/ntinclude.c
+++ b/ntinclude.c
@@ -70,8 +70,12 @@ pNtTestAlert NtTestAlert = NULL;
 pNtContinue NtContinue = NULL;
 pNtRaiseHardError NtRaiseHardError = NULL;
 
-#define RESOLVE(name) *(FARPROC*)&name = GetProcAddress(ntdll, #name); \
-    if (!name) printf("[!] %s nicht gefunden!\n", #name);
+#define RESOLVE(name) \ 
+    *(FARPROC *)&name = GetProcAddress(ntdll, #name); \ 
+    if (!(name)) { \ 
+        printf("[!] %s nicht gefunden!\n", #name); \ 
+        return FALSE; \ 
+    }
 
 BOOL ResolveNtFunctions() {
     HMODULE ntdll = GetModuleHandleA("ntdll.dll");


### PR DESCRIPTION
## Summary
- Return `FALSE` from `ResolveNtFunctions` when any NTAPI export fails to resolve.
- Document how to check `NTSTATUS` results when allocating memory via the wrapper.

## Testing
- `gcc -c ntinclude.c -o ntinclude.o` *(fails: Windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8bab57f08331a31a540236466c60