### PR TITLE
Fail early when NT functions can't be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 Eine kleine C-Library, die wichtige **Native API (NTAPI)** Funktionen aus `ntdll.dll` dynamisch auflöst.  
 Damit lassen sich NT-Funktionen bequem wie normale Windows-APIs nutzen, ohne jedes Mal `GetProcAddress` schreiben zu müssen.
 
-1. **`ntinclude.h` und `ntinclude.c`** in der `main.c` einbinden:  
+1. **`ntinclude.h` und `ntinclude.c`** in der `main.c` einbinden.
+   Unter Visual Studio reicht es, beide Dateien zum Projekt hinzuzufügen
+   oder auf der Kommandozeile zu kompilieren:
 
-2. Beim Start **Resolver aufrufen**:  
+   ```
+   cl /EHsc main.c ntinclude.c
+   ```
+
+2. Beim Start **Resolver aufrufen**:
 
    ```c
    if (!ResolveNtFunctions()) {
@@ -22,15 +28,19 @@ Damit lassen sich NT-Funktionen bequem wie normale Windows-APIs nutzen, ohne jed
 SIZE_T size = 0x1000;
 PVOID addr = NULL;
 
-if (NtAllocateVirtualMemory(
+NTSTATUS status = NtAllocateVirtualMemory(
     GetCurrentProcess(),
     &addr,
     0,
     &size,
     MEM_COMMIT | MEM_RESERVE,
     PAGE_READWRITE
-)) {
+);
+
+if (NT_SUCCESS(status)) {
     printf("Speicher allokiert bei %p\n", addr);
+} else {
+    printf("NtAllocateVirtualMemory fehlgeschlagen: 0x%lx\n", status);
 }
 ```
 

--- a/ntinclude.c
+++ b/ntinclude.c
@@ -70,8 +70,14 @@ pNtTestAlert NtTestAlert = NULL;
 pNtContinue NtContinue = NULL;
 pNtRaiseHardError NtRaiseHardError = NULL;
 
-#define RESOLVE(name) *(FARPROC*)&name = GetProcAddress(ntdll, #name); \
-    if (!name) printf("[!] %s nicht gefunden!\n", #name);
+#define RESOLVE(name) \
+    do { \
+        *(FARPROC *)&(name) = GetProcAddress(ntdll, #name); \
+        if (!(name)) { \
+            printf("[!] %s nicht gefunden!\n", #name); \
+            return FALSE; \
+        } \
+    } while (0)
 
 BOOL ResolveNtFunctions() {
     HMODULE ntdll = GetModuleHandleA("ntdll.dll");

--- a/ntinclude.h
+++ b/ntinclude.h
@@ -1,5 +1,9 @@
 #pragma once
-#include <Windows.h>
+#include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct _UNICODE_STRING {
     USHORT Length;
@@ -760,3 +764,7 @@ extern pNtContinue NtContinue;
 extern pNtRaiseHardError NtRaiseHardError;
 
 BOOL ResolveNtFunctions();
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- Return `FALSE` from `ResolveNtFunctions` when any NTAPI export fails to resolve
- Document Visual Studio usage and how to check `NTSTATUS` results
- Wrap `RESOLVE` macro in `do { … } while (0)` to keep multi-line expansion intact
- Expose header declarations to C++ by adding `extern "C"` guards

## Testing
- ⚠️ `cl /c ntinclude.c` (command not found)
- ⚠️ `x86_64-w64-mingw32-gcc -c ntinclude.c -o ntinclude.o` (command not found)
- ⚠️ `gcc -c ntinclude.c -o ntinclude.o` (missing `windows.h`)


------
https://chatgpt.com/codex/tasks/task_e_68bd8bab57f08331a31a540236466c60